### PR TITLE
Softdepend on RelicsOfCthonia

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <dependency>
             <groupId>com.github.Slimefun</groupId>
             <artifactId>Slimefun4</artifactId>
-            <version>RC-31</version>
+            <version>RC-32</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -72,6 +72,7 @@ softdepend:
   - VillagerUtil
   - MissileWarfare
   - SensibleToolbox
+  - RelicsOfCthonia
 
   ## This value is automatically replaced by the version specified in your pom.xml file, do not change this.
 version: ${project.version}


### PR DESCRIPTION
First of all sorry for the third PR xD 
Updated plugin.yml for the softdepend
Updated pom.xml from RC-31 to RC-32 because Slimefun version 31 no longer builds on JitPack due to an issue with a depended-upon repo. 