### PR TITLE
More ItemGroups

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,50 @@ The table below explains what each key does.
 
 ```yaml
 slime_customizer:
+  type: normal
   category-name: "&cSlimeCustomizer"
   category-item: REDSTONE_LAMP
+nested_group:
+  type: nested
+  category-name: "&cSlimeCustomizer - Nested"
+  category-item: BEDROCK
+sub_group:
+  type: sub
+  category-name: "&cSlimeCustomizer - Sub"
+  category-item: DIRT
+  parent: nested_group
+seasonal_group:
+  type: seasonal
+  category-name: "&cSlimeCustomizer - Seasonal"
+  category-item: DIAMOND
+  month: 9
+locked_group:
+  type: locked
+  category-name: "&cSlimeCustomizer - Locked"
+  category-item: DIAMOND
+  parents:
+    - slimefun:basic_machines
+
 ```
 
 | Key | Description |
 | -------- | -------- |
 | slime_customizer | The ID of the category. You can change this key! |
+| type | The type of the category. |
 | category-name | The name of the category that shows in the Slimefun guide. |
 | category-item | The vanilla material ID or skull hash of the item that this category will use in the Slimefun guide. |
+| tier | A number that indicates the position of this category in Slimefun Guide. Default: 3 |
+
+
+The types of category:
+- `normal`: the category type that all current categories belong to. Can contain items. **This is the default value.**
+- `nested`: a nested category can contain several sub categories, CANNOT contain items.
+- `sub`: a sub category is belong to a nested category, can contain items. **Required fields:**
+  - `parent`: the id of a nested category (from SlimeCustomizer)
+- `seasonal`: a seasonal category will only appear in Slimefun Guide in a specified month. **Required fields:**
+  - `month`: the numerical month. 1 = Jan, 2 = Feb, and so on...
+- `locked`: a locked category cannot be opened until all parent categories are fully unlocked. **Required fields:**
+  - `parents`: the list of NamespacedKeys of parent categories
 
 
 ##### Adding your item

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The types of category:
 - `seasonal`: a seasonal category will only appear in Slimefun Guide in a specified month. **Required fields:**
   - `month`: the numerical month. 1 = Jan, 2 = Feb, and so on...
 - `locked`: a locked category cannot be opened until all parent categories are fully unlocked. **Required fields:**
-  - `parents`: the list of NamespacedKeys of parent categories
+  - `parents`: the list of keys of parent categories. The key of a category is usually `<plugin name>:<category name>`. For example, the key of Basic Machines in Slimefun is `slimefun:basic_machines`.
 
 
 ##### Adding your item

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14.2-R0.1-SNAPSHOT</version>
+            <version>1.16.5-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/Registry.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/Registry.java
@@ -1,0 +1,19 @@
+package io.ncbpfluffybear.slimecustomizer;
+
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
+import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.collections.Pair;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Stores stuff.
+ *
+ * @author ybw0014
+ */
+public final class Registry {
+    public static final Map<ItemStack[], Pair<RecipeType, String>> existingRecipes = new HashMap<>();
+    public static final Map<String, ItemGroup> allItemGroups = new HashMap<>();
+}

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/SlimeCustomizer.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/SlimeCustomizer.java
@@ -48,9 +48,6 @@ public class SlimeCustomizer extends JavaPlugin implements SlimefunAddon {
     public static SlimeCustomizer instance;
     public static File itemsFolder;
 
-    public static final HashMap<ItemStack[], Pair<RecipeType, String>> existingRecipes = new HashMap<>();
-    public static final HashMap<String, ItemGroup> allCategories = new HashMap<>();
-
     @Override
     public void onEnable() {
 

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/Utils.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/Utils.java
@@ -1,6 +1,7 @@
 package io.ncbpfluffybear.slimecustomizer;
 
 import io.github.thebusybiscuit.slimefun4.api.items.SlimefunItem;
+import io.github.thebusybiscuit.slimefun4.api.items.groups.NestedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.recipes.RecipeType;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.libraries.dough.collections.Pair;
@@ -141,7 +142,7 @@ public class Utils {
 
         AtomicBoolean invalid = new AtomicBoolean(false);
 
-        SlimeCustomizer.existingRecipes.forEach((itemStacks, recipeTypePair) -> {
+        Registry.existingRecipes.forEach((itemStacks, recipeTypePair) -> {
             if (Arrays.equals(itemStacks, recipe) && recipeType == recipeTypePair.getFirstValue()) {
                 Utils.disable("The crafting recipe for " + key + " is already being used for "
                     + recipeTypePair.getSecondValue());
@@ -154,7 +155,7 @@ public class Utils {
         }
 
         if (!(recipeType == RecipeType.NULL)) {
-            SlimeCustomizer.existingRecipes.put(recipe, new Pair<>(recipeType, key));
+            Registry.existingRecipes.put(recipe, new Pair<>(recipeType, key));
         }
         return recipe;
     }
@@ -320,8 +321,8 @@ public class Utils {
     }
 
     public static ItemGroup getCategory(String str, String key) {
-        ItemGroup category = SlimeCustomizer.allCategories.get(str);
-        if (category == null) {
+        ItemGroup category = Registry.allItemGroups.get(str);
+        if (category == null || category instanceof NestedItemGroup) {
             disable(str + " is not a valid category for " + key + "!");
         }
         return category;

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
@@ -1,5 +1,6 @@
 package io.ncbpfluffybear.slimecustomizer.registration;
 
+import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.NestedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SeasonalItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SubItemGroup;
@@ -16,8 +17,8 @@ import org.bukkit.inventory.ItemStack;
 
 import java.time.DateTimeException;
 import java.time.Month;
+import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * {@link Categories} registers the categories
@@ -97,11 +98,20 @@ public class Categories {
                 }
 
                 tempCategory = new SeasonalItemGroup(key, month, tier, item);
+            } else if (type.equalsIgnoreCase("locked")) {
+                List<String> parents = categories.getStringList(categoryKey + ".parents");
+                NamespacedKey[] parentKeys = new NamespacedKey[parents.size()];
+                int i = 0;
+                for (String parent : parents) {
+                    parentKeys[i++] = NamespacedKey.fromString(parent, SlimeCustomizer.getInstance());
+                }
+
+                tempCategory = new LockedItemGroup(key, item, parentKeys);
             } else {
                 tempCategory = new ItemGroup(key, item);
             }
 
-            Registry.allItemGroups.put(categoryKey, tempCategory);
+            Registry.allItemGroups.put(itemGroupKey, tempCategory);
             Utils.notify("Category " + categoryKey + " has been registered!");
 
         }

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
@@ -1,16 +1,16 @@
 package io.ncbpfluffybear.slimecustomizer.registration;
 
+import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.LockedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.NestedItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SeasonalItemGroup;
 import io.github.thebusybiscuit.slimefun4.api.items.groups.SubItemGroup;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.config.Config;
+import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import io.github.thebusybiscuit.slimefun4.utils.SlimefunUtils;
 import io.ncbpfluffybear.slimecustomizer.Registry;
 import io.ncbpfluffybear.slimecustomizer.SlimeCustomizer;
 import io.ncbpfluffybear.slimecustomizer.Utils;
-import io.github.thebusybiscuit.slimefun4.api.items.ItemGroup;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.config.Config;
-import io.github.thebusybiscuit.slimefun4.libraries.dough.items.CustomItemStack;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.ItemStack;
@@ -40,6 +40,7 @@ public class Categories {
             String type = categories.getString(categoryKey + ".type");
             String name = categories.getString(categoryKey + ".category-name");
             String materialString = categories.getString(categoryKey + ".category-item");
+            String tierStr = categories.getString(categoryKey + ".tier");
             Material material = Material.getMaterial(materialString);
             ItemStack item = null;
 
@@ -68,9 +69,15 @@ public class Categories {
 
             ItemGroup tempCategory;
             NamespacedKey key = new NamespacedKey(SlimeCustomizer.getInstance(), itemGroupKey);
+            int tier;
+            try {
+                tier = Integer.parseInt(tierStr);
+            } catch (NumberFormatException ex) {
+                tier = 3;
+            }
 
             if (type.equalsIgnoreCase("nested")) {
-                tempCategory = new NestedItemGroup(key, item);
+                tempCategory = new NestedItemGroup(key, item, tier);
             } else if (type.equalsIgnoreCase("sub")) {
                 String parent = categories.getString(categoryKey + ".parent");
                 if (parent == null) {
@@ -84,10 +91,9 @@ public class Categories {
                     return false;
                 }
 
-                tempCategory = new SubItemGroup(key, (NestedItemGroup) parentGroup, item);
+                tempCategory = new SubItemGroup(key, (NestedItemGroup) parentGroup, item, tier);
             } else if (type.equalsIgnoreCase("seasonal")) {
                 int monthNum = categories.getInt(categoryKey + ".month");
-                int tier = categories.getInt(categoryKey + ".tier");
                 Month month;
 
                 try {
@@ -106,10 +112,10 @@ public class Categories {
                     parentKeys[i++] = NamespacedKey.fromString(parent, SlimeCustomizer.getInstance());
                 }
 
-                tempCategory = new LockedItemGroup(key, item, parentKeys);
+                tempCategory = new LockedItemGroup(key, item, tier, parentKeys);
             } else {
                 type = "normal";
-                tempCategory = new ItemGroup(key, item);
+                tempCategory = new ItemGroup(key, item, tier);
             }
 
             Registry.allItemGroups.put(itemGroupKey, tempCategory);

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
@@ -66,7 +66,7 @@ public class Categories {
                 return false;
             }
 
-            ItemGroup tempCategory = null;
+            ItemGroup tempCategory;
             NamespacedKey key = new NamespacedKey(SlimeCustomizer.getInstance(), itemGroupKey);
 
             if (type.equalsIgnoreCase("nested")) {
@@ -78,7 +78,7 @@ public class Categories {
                     return false;
                 }
 
-                ItemGroup parentGroup = Registry.allItemGroups.get(type);
+                ItemGroup parentGroup = Registry.allItemGroups.get(parent);
                 if (!(parentGroup instanceof NestedItemGroup)) {
                     Utils.disable("The category " + categoryKey + " has invalid parent group!");
                     return false;
@@ -108,11 +108,12 @@ public class Categories {
 
                 tempCategory = new LockedItemGroup(key, item, parentKeys);
             } else {
+                type = "normal";
                 tempCategory = new ItemGroup(key, item);
             }
 
             Registry.allItemGroups.put(itemGroupKey, tempCategory);
-            Utils.notify("Category " + categoryKey + " has been registered!");
+            Utils.notify("Category " + categoryKey + " (" + type + ") has been registered!");
 
         }
 

--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/registration/Categories.java
@@ -118,7 +118,7 @@ public class Categories {
                 tempCategory = new ItemGroup(key, item, tier);
             }
 
-            Registry.allItemGroups.put(itemGroupKey, tempCategory);
+            Registry.allItemGroups.put(categoryKey, tempCategory);
             Utils.notify("Category " + categoryKey + " (" + type + ") has been registered!");
 
         }

--- a/src/main/resources/categories.yml
+++ b/src/main/resources/categories.yml
@@ -1,4 +1,25 @@
 #READ THE WIKI BEFORE CREATING A CATEGORY! https://github.com/NCBPFluffyBear/SlimeCustomizer/blob/master/README.md
 slime_customizer:
+  type: normal
   category-name: "&cSlimeCustomizer"
   category-item: REDSTONE_LAMP
+nested_group:
+  type: nested
+  category-name: "&cSlimeCustomizer - Nested"
+  category-item: BEDROCK
+sub_group:
+  type: sub
+  category-name: "&cSlimeCustomizer - Sub"
+  category-item: DIRT
+  parent: nested_group
+seasonal_group:
+  type: seasonal
+  category-name: "&cSlimeCustomizer - Seasonal"
+  category-item: DIAMOND
+  month: 9
+locked_group:
+  type: locked
+  category-name: "&cSlimeCustomizer - Locked"
+  category-item: DIAMOND
+  parents:
+    - slimecustomizer:slime_customizer

--- a/src/main/resources/categories.yml
+++ b/src/main/resources/categories.yml
@@ -22,4 +22,4 @@ locked_group:
   category-name: "&cSlimeCustomizer - Locked"
   category-item: DIAMOND
   parents:
-    - slimecustomizer:slime_customizer
+    - slimefun:basic_machines

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -78,7 +78,7 @@ softdepend:
 version: ${project.version}
 
 ## This is the minimum minecraft version required to run your plugin.
-api-version: 1.14
+api-version: 1.16
 
 commands:
   slimecustomizer:


### PR DESCRIPTION
Changed the minimum Minecraft version to 1.16.

Add `type` to categories, here are available types:
- `normal`: the category type that all current categories belong to. Can contain items.
- `nested`: a nested category can contain several sub categories, CANNOT contain items.
- `sub`: a sub category is belong to a nested category, can contain items. *Required fields:* 
  - `parent`: the id of a nested category (from SlimeCustomizer)
- `seasonal`: a seasonal category will only appear in Slimefun Guide in a specified month. *Required fields:* 
  - `month`: the numerical month. 1 = Jan, 2 = Feb, and so on...
  - `tier`: a number that indicates the position of the category in Slimefun Guide, default for most categories is 3.
- `locked`: a locked category cannot be opened until all parent categories are fully unlocked. *Required fields:* 
  - `parents`: the list of NamespacedKeys of parent categories