### PR TITLE
Changed mob drop load order

### DIFF
--- a/src/main/java/io/ncbpfluffybear/slimecustomizer/SlimeCustomizer.java
+++ b/src/main/java/io/ncbpfluffybear/slimecustomizer/SlimeCustomizer.java
@@ -67,12 +67,12 @@ public class SlimeCustomizer extends JavaPlugin implements SlimefunAddon {
         final File categoriesFile = new File(getInstance().getDataFolder(), "categories.yml");
         copyFile(categoriesFile, "categories");
 
-        final File itemsFile = new File(getInstance().getDataFolder(), "items.yml");
-        copyFile(itemsFile, "items");
-
         final File mobDropsFile = new File(getInstance().getDataFolder(), "mob-drops.yml");
         copyFile(mobDropsFile, "mob-drops");
 
+
+        final File itemsFile = new File(getInstance().getDataFolder(), "items.yml");
+        copyFile(itemsFile, "items");
 
         final File machinesFile = new File(getInstance().getDataFolder(), "machines.yml");
         copyFile(machinesFile, "machines");
@@ -107,22 +107,22 @@ public class SlimeCustomizer extends JavaPlugin implements SlimefunAddon {
         }
 
         Config categories = new Config(this, "categories.yml");
+        Config mobDrops = new Config(this, "mob-drops.yml");
         Config items = new Config(this, "items.yml");
         Config machines = new Config(this, "machines.yml");
         Config generators = new Config(this, "generators.yml");
         Config solarGenerators = new Config(this, "solar-generators.yml");
         Config passiveMachines = new Config(this, "passive-machines.yml");
-        Config mobDrops = new Config(this, "mob-drops.yml");
 
         this.getCommand("slimecustomizer").setTabCompleter(new SCTabCompleter());
 
         Bukkit.getConsoleSender().sendMessage("[SlimeCustomizer] " + ChatColor.BLUE + "Setting up custom stuff...");
         if (!Categories.register(categories)) {return;}
+        if (!MobDrops.register(mobDrops)) {return;}
         if (!Items.register(items)) {return;}
         if (!Machines.register(machines)) {return;}
         if (!Generators.register(generators)) {return;}
         if (!SolarGenerators.register(solarGenerators)) {return;}
-        if (!MobDrops.register(mobDrops)) {return;}
         Bukkit.getPluginManager().registerEvents(new Events(), instance);
     }
 


### PR DESCRIPTION
Changed load order of mob-drops.yml to be before all the other ymls but categories, that way items defined in mob-drops.yml can be referenced in other ymls